### PR TITLE
Optimize Ingestor write() with in-memory DataFrame caching

### DIFF
--- a/pocaduck/ingestor.py
+++ b/pocaduck/ingestor.py
@@ -22,29 +22,31 @@ from .storage_config import StorageConfig
 class Ingestor:
     """
     Handles ingestion of point clouds for labels within blocks.
-    
+
     The Ingestor class provides methods to write 3D point clouds associated with labels
     within blocks and to finalize the ingestion process. Each worker should have its own
     Ingestor instance.
-    
+
     Attributes:
         storage_config: Configuration for storage backend.
         worker_id: Unique identifier for the worker.
         max_points_per_file: Maximum number of points to store in a single parquet file.
         current_points_count: Current count of points written to the current parquet file.
-        current_file_id: Identifier for the current parquet file.
+        file_counter: Counter to track the file number for sequential naming.
+        current_file_path: Path to the current parquet file being written.
+        current_file_df: In-memory DataFrame cache for the current file.
         db_connection: Connection to the DuckDB database for indexing.
     """
     
     def __init__(
-        self, 
-        storage_config: StorageConfig, 
+        self,
+        storage_config: StorageConfig,
         worker_id: Union[str, int],
         max_points_per_file: int = 10_000_000,
     ):
         """
         Initialize an Ingestor instance.
-        
+
         Args:
             storage_config: Configuration for storage backend.
             worker_id: Unique identifier for the worker.
@@ -55,21 +57,23 @@ class Ingestor:
         self.max_points_per_file = max_points_per_file
         self.current_points_count = 0
         self.file_counter = 0  # Counter to track the file number for sequential naming
-        
+        self.current_file_path = None  # Path to the current parquet file
+        self.current_file_df = None    # DataFrame cache for the current file
+
         # Set up logging
         import logging
         self.logger = logging.getLogger(__name__)
-        
+
         # Set up storage paths
         base_path = storage_config.base_path
         self.worker_dir = os.path.join(base_path, f"worker_{self.worker_id}")
         self.data_dir = os.path.join(self.worker_dir, "data")
         self.db_path = os.path.join(self.worker_dir, f"index_{self.worker_id}.db")
-        
+
         # Create directories if necessary
         if storage_config.storage_type == "local":
             os.makedirs(self.data_dir, exist_ok=True)
-        
+
         # Set up database connection
         self.db_connection = self._initialize_db_connection()
     
@@ -104,110 +108,121 @@ class Ingestor:
         
         return con
     
+    def _flush_current_file(self):
+        """
+        Flush the current DataFrame to a parquet file.
+        """
+        if self.current_file_df is not None and len(self.current_file_df) > 0:
+            self.logger.info(f"Worker {self.worker_id}: Flushing {len(self.current_file_df)} rows to {os.path.basename(self.current_file_path)}")
+
+            # Write DataFrame to parquet
+            self.current_file_df.to_parquet(self.current_file_path, index=False)
+
+            # Reset DataFrame to clear memory
+            self.current_file_df = None
+
     def write(
-        self, 
-        label: int, 
-        block_id: str, 
+        self,
+        label: int,
+        block_id: str,
         points: np.ndarray
     ) -> None:
         """
         Write point cloud data for a label within a block.
-        
+
         Args:
             label: The uint64 label identifier.
             block_id: Identifier for the block containing the points.
             points: Numpy array of shape (N, D) containing point data where D is the dimension
                    of the data (e.g., 3 for just x,y,z coordinates, or more for additional attributes).
-            
+
         Raises:
             ValueError: If points is not a valid numpy array.
         """
         # Validate input
         if not isinstance(points, np.ndarray) or points.ndim != 2:
             raise ValueError("Points must be a numpy array of shape (N, D) containing point data")
-        
+
         num_points = points.shape[0]
         if num_points == 0:
             return  # Skip empty point clouds
-        
+
         # Handle points in batches respecting max_points_per_file limit
         remaining_points = points
         points_written = 0
-        
+
         while points_written < num_points:
             # Calculate how many points we can add to the current file
             space_in_current_file = self.max_points_per_file - self.current_points_count
             points_to_write = min(space_in_current_file, len(remaining_points))
-            
+
             if points_to_write <= 0:
-                # Current file is full, increment counter and start a new file
+                # Current file is full, flush it and start a new file
+                self._flush_current_file()
                 old_counter = self.file_counter
                 self.file_counter += 1
                 self.current_points_count = 0
+                self.current_file_path = None
+                self.current_file_df = None
                 self.logger.info(f"Worker {self.worker_id}: Incrementing file counter from {old_counter} to {self.file_counter}")
                 continue  # Recalculate space in the new file
-            
+
             # Select the batch of points to write to this file
             batch = remaining_points[:points_to_write]
-            
-            # Get file path for the current file with human-readable name
-            file_path = os.path.join(self.data_dir, f"{self.worker_id}-{self.file_counter}.parquet")
-            self.logger.info(f"Worker {self.worker_id}: Writing to file {os.path.basename(file_path)}, "
-                            f"current point count: {self.current_points_count}, "
-                            f"adding {len(batch)} points "
-                            f"(batch {points_written+1}-{points_written+len(batch)} of {num_points})")
-            
+
+            # Get or create the file path for the current file
+            if self.current_file_path is None:
+                self.current_file_path = os.path.join(self.data_dir, f"{self.worker_id}-{self.file_counter}.parquet")
+                self.logger.info(f"Worker {self.worker_id}: Using file {os.path.basename(self.current_file_path)}, "
+                                f"current point count: {self.current_points_count}, "
+                                f"adding {len(batch)} points "
+                                f"(batch {points_written+1}-{points_written+len(batch)} of {num_points})")
+
             # Create DataFrame from batch of points
             # Ensure label is handled as a BIGINT to avoid type inconsistencies
-            df = pd.DataFrame({
+            batch_df = pd.DataFrame({
                 'label': pd.Series([label] * len(batch), dtype='int64'),
                 'block_id': block_id,
                 'data': list(batch)  # Store each row of points as a list in the 'data' column
             })
-            
-            # Write to parquet file (append if it exists)
-            if os.path.exists(file_path) and self.storage_config.storage_type == "local":
-                self.logger.info(f"Appending to existing file {os.path.basename(file_path)}")
-                
-                # We'll use DuckDB to efficiently read the existing file
-                # This is more efficient for large files than pd.read_parquet
-                existing_df = self.db_connection.execute(f"SELECT * FROM read_parquet('{file_path}')").fetchdf()
-                
-                # Append new data
-                df = pd.concat([existing_df, df])
-            else:
-                self.logger.info(f"Creating new file {os.path.basename(file_path)}")
-                
-            # Write to parquet
-            df.to_parquet(file_path, index=False)
-            
-            # When we split files, we need a different approach to index management.
-            # If this is the first chunk of points for this label-block combination,
-            # we'll create a new index entry with the file path.
-            # For subsequent chunks, we'll just update the point count
-            # without overwriting the file path, since we need to keep a reference
-            # to all files with these points.
-            
+
+            # Check if this is an existing file that needs to be loaded first
+            if self.current_file_df is None:
+                if os.path.exists(self.current_file_path) and self.storage_config.storage_type == "local":
+                    self.logger.info(f"Loading existing file {os.path.basename(self.current_file_path)}")
+
+                    # Use DuckDB to efficiently read the existing file
+                    self.current_file_df = self.db_connection.execute(
+                        f"SELECT * FROM read_parquet('{self.current_file_path}')"
+                    ).fetchdf()
+                else:
+                    # New file, initialize empty DataFrame
+                    self.current_file_df = pd.DataFrame(columns=['label', 'block_id', 'data'])
+
+            # Append new data to in-memory DataFrame
+            self.current_file_df = pd.concat([self.current_file_df, batch_df])
+
+            # Update the index
             # Check if this is a new entry for this label-block combination
             existing_entry = self.db_connection.execute("""
-                SELECT file_path, point_count FROM point_cloud_index 
+                SELECT file_path, point_count FROM point_cloud_index
                 WHERE label = ? AND block_id = ?
             """, [label, block_id]).fetchone()
-            
+
             if existing_entry:
                 # This label-block combo exists in the index
                 # Add a new entry with this file path
                 self.db_connection.execute("""
                     INSERT INTO point_cloud_index (label, block_id, file_path, point_count)
                     VALUES (?, ?, ?, ?)
-                """, [label, block_id, file_path, len(batch)])
+                """, [label, block_id, self.current_file_path, len(batch)])
             else:
                 # This is a new label-block combination
                 self.db_connection.execute("""
                     INSERT INTO point_cloud_index (label, block_id, file_path, point_count)
                     VALUES (?, ?, ?, ?)
-                """, [label, block_id, file_path, len(batch)])
-            
+                """, [label, block_id, self.current_file_path, len(batch)])
+
             # Update tracking variables
             self.current_points_count += len(batch)
             points_written += len(batch)
@@ -216,13 +231,16 @@ class Ingestor:
     def finalize(self) -> None:
         """
         Finalize the ingestion process for this worker.
-        
+
         This method should be called when the worker has completed all writes.
-        It ensures all data is properly committed and closes connections.
+        It ensures all data is properly flushed to disk, committed and closes connections.
         """
+        # Flush any pending data to disk
+        self._flush_current_file()
+
         # Commit any pending transactions
         self.db_connection.commit()
-        
+
         # Close the database connection
         self.db_connection.close()
     


### PR DESCRIPTION
- Replace repetitive parquet read/write with in-memory DataFrame caching
- Add _flush_current_file() method that only writes to disk when necessary
- Update finalize() to ensure cached data is flushed before closing
- Improve efficiency by reducing disk I/O operations during point ingestion

@stuarteberg 