### PR TITLE
Add optional optimization to restructure data for label-specific queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,21 @@ The optimization process:
 2. Reorganizes points by label into optimized parquet files
 3. Creates a new optimized index for efficient label-based lookups
 
+The optimized data is stored in a standard directory structure:
+```
+/base_path/
+├── unified_index.db              # Original index
+├── worker_1/                     # Original ingestion worker dirs
+├── worker_2/
+└── optimized/                    # Optimization directory
+    ├── optimized_index.db        # Consolidated optimized index
+    ├── optimize_worker1/         # Optimizer worker directories
+    │   ├── metadata.json         # Worker metadata
+    │   ├── optimized_*.parquet   # Optimized parquet files
+    └── optimize_worker2/
+        └── ...
+```
+
 After optimization, the Query class automatically detects and uses the optimized data structure with no code changes required.
 
 ### Running the Optimization Pipeline

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ python optimize_point_cloud.py --action optimize --base-path /path/to/data \
 python optimize_point_cloud.py --action consolidate --base-path /path/to/data
 ```
 
+**Note**: If interrupted, workers should be restarted from the beginning with a fresh worker directory.
+
 ### Key Options
 
 - `--target-file-size`: Target size for optimized parquet files (default: 500MB)

--- a/optimize_point_cloud.py
+++ b/optimize_point_cloud.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python
+"""
+PoCADuck Point Cloud Optimizer
+
+This script reorganizes point cloud data to optimize label-based queries.
+It groups points for each label into contiguous regions in optimized parquet files,
+significantly improving query performance.
+
+The optimizer can be run in parallel on different subsets of labels, with a final
+consolidation step to merge the results.
+"""
+
+import os
+import sys
+import time
+import argparse
+import uuid
+import json
+from typing import List, Optional, Set, Dict, Any
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import duckdb
+from tqdm import tqdm
+
+from pocaduck.storage_config import StorageConfig
+
+def optimize_point_clouds(
+    storage_config: StorageConfig,
+    source_index_path: str,
+    target_path: Optional[str] = None,
+    worker_id: str = "default",
+    target_file_size: int = 500 * 1024 * 1024,  # 500MB default target size
+    batch_size: int = 100,  # Process this many labels at once
+    labels_to_process: Optional[List[int]] = None,
+    threads: Optional[int] = None,
+    verbose: bool = True
+) -> str:
+    """
+    Reorganize point cloud data to optimize label-based queries.
+    
+    Args:
+        storage_config: Storage configuration for source and target.
+        source_index_path: Path to the existing unified index.
+        target_path: Path where optimized files will be stored. If None, uses a
+                    subdirectory "optimized" under the storage_config base_path.
+        worker_id: Unique identifier for this optimization worker.
+        target_file_size: Target size for optimized parquet files in bytes.
+        batch_size: Number of labels to process in a single batch to manage memory.
+        labels_to_process: Optional list of specific labels to process. If None, all labels are processed.
+        threads: Number of threads to use for DuckDB processing. If None, uses system default.
+        verbose: Whether to print progress information.
+    
+    Returns:
+        Path to the worker's metadata file containing information about processed labels.
+    """
+    # Set up paths
+    if target_path is None:
+        target_path = os.path.join(storage_config.base_path, "optimized")
+    
+    # Create optimized directory and worker subdirectory
+    worker_dir = os.path.join(target_path, f"worker_{worker_id}")
+    os.makedirs(worker_dir, exist_ok=True)
+    
+    # Path for worker metadata
+    worker_metadata_path = os.path.join(worker_dir, "metadata.json")
+    
+    # Check if this worker has already done some work
+    processed_labels = set()
+    if os.path.exists(worker_metadata_path):
+        try:
+            with open(worker_metadata_path, 'r') as f:
+                metadata = json.load(f)
+                processed_info = metadata.get("processed_labels", {})
+                processed_labels = set(int(label) for label in processed_info.keys())
+                if verbose:
+                    print(f"Found {len(processed_labels)} previously processed labels for worker {worker_id}")
+        except Exception as e:
+            if verbose:
+                print(f"Error reading metadata file: {e}")
+    
+    # Connect to source index
+    src_con = duckdb.connect(source_index_path, read_only=True)
+    
+    # Apply storage configuration
+    duckdb_config = storage_config.get_duckdb_config()
+    for key, value in duckdb_config.items():
+        src_con.execute(f"SET {key}='{value}'")
+    
+    # Set threads if specified
+    if threads is not None:
+        src_con.execute(f"PRAGMA threads={threads}")
+    
+    # Get all unique labels or use provided labels
+    if labels_to_process is None:
+        if verbose:
+            print("Fetching all unique labels from the index...")
+        labels = src_con.execute("SELECT DISTINCT label FROM point_cloud_index ORDER BY label").fetchall()
+        labels = [label[0] for label in labels]
+        if verbose:
+            print(f"Found {len(labels)} unique labels")
+    else:
+        labels = labels_to_process
+        if verbose:
+            print(f"Processing {len(labels)} specified labels")
+    
+    # Filter out already processed labels
+    if processed_labels:
+        original_count = len(labels)
+        labels = [label for label in labels if label not in processed_labels]
+        if verbose:
+            print(f"Filtered out {original_count - len(labels)} already processed labels")
+    
+    # Load or initialize worker metadata
+    worker_metadata = {
+        "worker_id": worker_id,
+        "processed_labels": {},
+        "files": []
+    }
+    
+    if os.path.exists(worker_metadata_path):
+        try:
+            with open(worker_metadata_path, 'r') as f:
+                worker_metadata = json.load(f)
+        except Exception as e:
+            if verbose:
+                print(f"Error loading existing metadata, starting fresh: {e}")
+    
+    # Process labels in batches to manage memory
+    current_file_path = None
+    current_file_size = 0
+    processed_count = 0
+    total_points = 0
+    start_time = time.time()
+    
+    if verbose:
+        print(f"Processing {len(labels)} labels in batches of {batch_size}...")
+    
+    for i in range(0, len(labels), batch_size):
+        batch_labels = labels[i:i+batch_size]
+        if verbose:
+            print(f"Processing batch {i//batch_size + 1}/{(len(labels) + batch_size - 1)//batch_size}: "
+                  f"{len(batch_labels)} labels")
+        
+        batch_progress = tqdm(batch_labels, desc="Labels", unit="label") if verbose else batch_labels
+        for label in batch_progress:
+            # Get file paths containing this label
+            file_info = src_con.execute(
+                "SELECT file_path FROM point_cloud_index WHERE label = ?",
+                [label]
+            ).fetchall()
+            
+            file_paths = [info[0] for info in file_info]
+            
+            if not file_paths:
+                if verbose:
+                    print(f"Skipping label {label}: no data found")
+                continue
+            
+            # Use DuckDB to efficiently read the point data
+            query = f"""
+                SELECT data
+                FROM parquet_scan([{','.join(f"'{path}'" for path in file_paths)}])
+                WHERE label = {label}
+            """
+            
+            try:
+                # Get points as DataFrame
+                df = src_con.execute(query).fetchdf()
+                
+                if len(df) == 0:
+                    if verbose:
+                        print(f"Skipping label {label}: no point data returned")
+                    continue
+                
+                # Stack points and remove duplicates
+                points_list = df['data'].tolist()
+                points = np.vstack(points_list).astype(np.int64)
+                points = np.unique(points, axis=0)
+                
+                # Calculate size of this label's points
+                # Rough estimate: points array size + overhead
+                point_size_bytes = points.nbytes + 1000  # Add overhead
+                
+                # If adding this would exceed target file size, create a new file
+                if current_file_path is None or current_file_size + point_size_bytes > target_file_size:
+                    # Create new file
+                    file_id = str(uuid.uuid4())
+                    current_file_path = os.path.join(worker_dir, f"optimized_{file_id}.parquet")
+                    current_file_size = 0
+                    
+                    # Add file to metadata
+                    if current_file_path not in worker_metadata["files"]:
+                        worker_metadata["files"].append(current_file_path)
+                
+                # Prepare data for writing
+                point_df = pd.DataFrame({
+                    'label': label,
+                    'data': [points]  # Store as a single array
+                })
+                
+                # Write to file
+                if current_file_size == 0:
+                    # New file
+                    point_df.to_parquet(current_file_path, index=False)
+                else:
+                    # Append to existing file
+                    point_df.to_parquet(current_file_path, index=False, append=True)
+                
+                # Update size tracking
+                new_size = os.path.getsize(current_file_path)
+                point_size_actual = new_size - current_file_size
+                current_file_size = new_size
+                
+                # Add label info to metadata
+                worker_metadata["processed_labels"][str(label)] = {
+                    "file_path": current_file_path,
+                    "point_count": int(len(points))
+                }
+                
+                # Save metadata periodically (every 10 labels)
+                if processed_count % 10 == 0:
+                    with open(worker_metadata_path, 'w') as f:
+                        json.dump(worker_metadata, f, indent=2)
+                
+                processed_count += 1
+                total_points += len(points)
+                
+            except Exception as e:
+                if verbose:
+                    print(f"Error processing label {label}: {str(e)}")
+    
+    # Save final metadata
+    with open(worker_metadata_path, 'w') as f:
+        json.dump(worker_metadata, f, indent=2)
+    
+    # Close connection
+    src_con.close()
+    
+    end_time = time.time()
+    elapsed = end_time - start_time
+    
+    if verbose:
+        print("\nWorker optimization complete!")
+        print(f"- Worker ID: {worker_id}")
+        print(f"- Processed: {processed_count} labels")
+        print(f"- Total points: {total_points:,}")
+        print(f"- Elapsed time: {elapsed:.2f} seconds ({elapsed/60:.2f} minutes)")
+        print(f"- Worker metadata: {worker_metadata_path}")
+        if processed_count > 0:
+            print(f"- Points per second: {total_points/elapsed:,.2f}")
+    
+    return worker_metadata_path
+
+def consolidate_optimized_indices(
+    storage_config: StorageConfig,
+    target_path: Optional[str] = None,
+    target_index_path: Optional[str] = None,
+    threads: Optional[int] = None,
+    verbose: bool = True
+) -> None:
+    """
+    Consolidate optimized indices from multiple workers into a single optimized index.
+    
+    Args:
+        storage_config: Storage configuration.
+        target_path: Path where optimized files are stored. If None, uses a
+                    subdirectory "optimized" under the storage_config base_path.
+        target_index_path: Path for the consolidated index. If None, uses
+                          "{target_path}/optimized_index.db".
+        threads: Number of threads to use for DuckDB processing. If None, uses system default.
+        verbose: Whether to print progress information.
+    """
+    # Set up paths
+    if target_path is None:
+        target_path = os.path.join(storage_config.base_path, "optimized")
+    
+    if target_index_path is None:
+        target_index_path = os.path.join(target_path, "optimized_index.db")
+    
+    if verbose:
+        print(f"Consolidating optimized indices from {target_path}")
+        print(f"Target index: {target_index_path}")
+    
+    # Find all worker directories
+    worker_dirs = [d for d in os.listdir(target_path) 
+                   if os.path.isdir(os.path.join(target_path, d)) and d.startswith("worker_")]
+    
+    if not worker_dirs:
+        if verbose:
+            print("No worker directories found. Nothing to consolidate.")
+        return
+    
+    if verbose:
+        print(f"Found {len(worker_dirs)} worker directories")
+    
+    # Create/connect to target index
+    if os.path.exists(target_index_path):
+        if verbose:
+            print(f"Removing existing index at {target_index_path}")
+        os.remove(target_index_path)
+    
+    target_con = duckdb.connect(target_index_path)
+    
+    # Apply storage configuration
+    duckdb_config = storage_config.get_duckdb_config()
+    for key, value in duckdb_config.items():
+        target_con.execute(f"SET {key}='{value}'")
+    
+    # Set threads if specified
+    if threads is not None:
+        target_con.execute(f"PRAGMA threads={threads}")
+    
+    # Create the new optimized schema
+    target_con.execute("""
+        CREATE TABLE point_cloud_index (
+            label BIGINT,
+            file_path VARCHAR,
+            point_count BIGINT
+        )
+    """)
+    
+    # Process each worker's metadata
+    total_labels = 0
+    for worker_dir in sorted(worker_dirs):
+        worker_path = os.path.join(target_path, worker_dir)
+        metadata_path = os.path.join(worker_path, "metadata.json")
+        
+        if not os.path.exists(metadata_path):
+            if verbose:
+                print(f"Skipping {worker_dir}: No metadata file found")
+            continue
+        
+        try:
+            with open(metadata_path, 'r') as f:
+                metadata = json.load(f)
+            
+            worker_id = metadata.get("worker_id", worker_dir.replace("worker_", ""))
+            processed_labels = metadata.get("processed_labels", {})
+            
+            if verbose:
+                print(f"Processing {worker_dir} (worker_id: {worker_id}): {len(processed_labels)} labels")
+            
+            # Insert worker's labels into the consolidated index
+            for label_str, info in processed_labels.items():
+                label = int(label_str)
+                file_path = info["file_path"]
+                point_count = info["point_count"]
+                
+                target_con.execute("""
+                    INSERT INTO point_cloud_index 
+                    (label, file_path, point_count) 
+                    VALUES (?, ?, ?)
+                """, [label, file_path, point_count])
+            
+            total_labels += len(processed_labels)
+            
+        except Exception as e:
+            if verbose:
+                print(f"Error processing {worker_dir}: {str(e)}")
+    
+    # Create indexes for performance
+    if verbose:
+        print("Creating index on label column...")
+    target_con.execute("CREATE INDEX idx_label ON point_cloud_index(label)")
+    
+    # Commit and close connection
+    target_con.close()
+    
+    if verbose:
+        print(f"Consolidation complete! Total labels in optimized index: {total_labels}")
+
+def shard_labels(
+    storage_config: StorageConfig,
+    source_index_path: str,
+    num_shards: int,
+    output_dir: Optional[str] = None,
+    verbose: bool = True
+) -> List[str]:
+    """
+    Shard labels into multiple files for parallel processing.
+    
+    Args:
+        storage_config: Storage configuration.
+        source_index_path: Path to the source index.
+        num_shards: Number of shards to create.
+        output_dir: Directory to write shard files. If None, uses current directory.
+        verbose: Whether to print progress information.
+    
+    Returns:
+        List of paths to the shard files.
+    """
+    if output_dir is None:
+        output_dir = os.getcwd()
+    
+    os.makedirs(output_dir, exist_ok=True)
+    
+    # Connect to source index
+    src_con = duckdb.connect(source_index_path, read_only=True)
+    
+    # Apply storage configuration
+    duckdb_config = storage_config.get_duckdb_config()
+    for key, value in duckdb_config.items():
+        src_con.execute(f"SET {key}='{value}'")
+    
+    # Get all labels
+    if verbose:
+        print("Fetching all labels...")
+    
+    labels = src_con.execute("SELECT DISTINCT label FROM point_cloud_index ORDER BY label").fetchall()
+    labels = [label[0] for label in labels]
+    
+    src_con.close()
+    
+    if verbose:
+        print(f"Found {len(labels)} labels")
+    
+    # Create shards
+    shard_size = (len(labels) + num_shards - 1) // num_shards  # Ceiling division
+    shards = [labels[i:i+shard_size] for i in range(0, len(labels), shard_size)]
+    
+    if verbose:
+        print(f"Created {len(shards)} shards with ~{shard_size} labels each")
+    
+    # Write shards to files
+    shard_files = []
+    for i, shard in enumerate(shards):
+        shard_file = os.path.join(output_dir, f"labels_shard_{i}.txt")
+        with open(shard_file, 'w') as f:
+            f.write("\n".join(str(label) for label in shard))
+        
+        shard_files.append(shard_file)
+        
+        if verbose:
+            print(f"Wrote {len(shard)} labels to {shard_file}")
+    
+    return shard_files
+
+def main():
+    """Command-line entry point for the optimization script."""
+    parser = argparse.ArgumentParser(description="PoCADuck Point Cloud Optimizer")
+    
+    parser.add_argument("--base-path", type=str, required=True,
+                        help="Base path for storage configuration")
+    parser.add_argument("--source-index", type=str,
+                        help="Path to source index (if different from base_path/unified_index.db)")
+    parser.add_argument("--target-path", type=str,
+                        help="Path where optimized files will be stored (default: base_path/optimized)")
+    parser.add_argument("--target-index", type=str,
+                        help="Path for the new optimized index (default: target_path/optimized_index.db)")
+    parser.add_argument("--target-file-size", type=int, default=500 * 1024 * 1024,
+                        help="Target size for optimized parquet files in bytes (default: 500MB)")
+    parser.add_argument("--batch-size", type=int, default=100,
+                        help="Number of labels to process in a single batch (default: 100)")
+    parser.add_argument("--threads", type=int,
+                        help="Number of threads to use for DuckDB processing (default: system default)")
+    parser.add_argument("--worker-id", type=str, default=str(uuid.uuid4())[:8],
+                        help="Unique identifier for this optimization worker (default: random UUID)")
+    
+    # Command selection arguments
+    parser.add_argument("--action", type=str, required=True, 
+                        choices=["optimize", "consolidate", "shard"],
+                        help="Action to perform: optimize, consolidate, or shard")
+    
+    # Shard-specific arguments
+    parser.add_argument("--num-shards", type=int, 
+                        help="Number of shards to create (for --action=shard)")
+    parser.add_argument("--shard-output-dir", type=str,
+                        help="Directory to write shard files (for --action=shard)")
+    
+    # Label selection arguments
+    parser.add_argument("--labels", type=str,
+                        help="Comma-separated list of labels to process (default: all labels)")
+    parser.add_argument("--labels-file", type=str,
+                        help="File containing labels to process, one per line (default: all labels)")
+    
+    # Add cloud storage related arguments
+    parser.add_argument("--storage-type", type=str, default="local",
+                        choices=["local", "s3", "gcs", "azure"],
+                        help="Storage backend type (default: local)")
+    parser.add_argument("--region", type=str,
+                        help="Cloud region (for S3, GCS)")
+    parser.add_argument("--endpoint", type=str,
+                        help="Custom endpoint URL (for S3)")
+    parser.add_argument("--access-key", type=str,
+                        help="Access key ID (for S3, Azure)")
+    parser.add_argument("--secret-key", type=str,
+                        help="Secret access key (for S3, Azure)")
+    parser.add_argument("--token", type=str,
+                        help="Session token (for S3)")
+    parser.add_argument("--container", type=str,
+                        help="Container name (for Azure)")
+    
+    # Verbosity control
+    parser.add_argument("--quiet", action="store_true",
+                        help="Suppress progress output")
+    
+    args = parser.parse_args()
+    
+    # Configure storage
+    storage_kwargs = {
+        "base_path": args.base_path,
+        "storage_type": args.storage_type
+    }
+    
+    # Add cloud-specific parameters if provided
+    if args.region:
+        storage_kwargs["region"] = args.region
+    if args.endpoint:
+        storage_kwargs["endpoint_url"] = args.endpoint
+    if args.access_key:
+        storage_kwargs["access_key_id"] = args.access_key
+    if args.secret_key:
+        storage_kwargs["secret_access_key"] = args.secret_key
+    if args.token:
+        storage_kwargs["session_token"] = args.token
+    if args.container:
+        storage_kwargs["container"] = args.container
+    
+    storage_config = StorageConfig(**storage_kwargs)
+    
+    # Get source index path
+    source_index_path = args.source_index
+    if source_index_path is None:
+        source_index_path = os.path.join(args.base_path, "unified_index.db")
+    
+    verbose = not args.quiet
+    
+    # Handle different actions
+    if args.action == "optimize":
+        # Get labels to process
+        labels_to_process = None
+        if args.labels:
+            labels_to_process = [int(label.strip()) for label in args.labels.split(",")]
+        elif args.labels_file:
+            with open(args.labels_file, 'r') as f:
+                labels_to_process = [int(line.strip()) for line in f if line.strip()]
+        
+        # Run optimization
+        optimize_point_clouds(
+            storage_config=storage_config,
+            source_index_path=source_index_path,
+            target_path=args.target_path,
+            worker_id=args.worker_id,
+            target_file_size=args.target_file_size,
+            batch_size=args.batch_size,
+            labels_to_process=labels_to_process,
+            threads=args.threads,
+            verbose=verbose
+        )
+    
+    elif args.action == "consolidate":
+        # Run consolidation
+        consolidate_optimized_indices(
+            storage_config=storage_config,
+            target_path=args.target_path,
+            target_index_path=args.target_index,
+            threads=args.threads,
+            verbose=verbose
+        )
+    
+    elif args.action == "shard":
+        if not args.num_shards:
+            parser.error("--num-shards is required for shard action")
+        
+        # Run sharding
+        shard_labels(
+            storage_config=storage_config,
+            source_index_path=source_index_path,
+            num_shards=args.num_shards,
+            output_dir=args.shard_output_dir,
+            verbose=verbose
+        )
+
+if __name__ == "__main__":
+    main()

--- a/optimize_point_cloud.py
+++ b/optimize_point_cloud.py
@@ -449,8 +449,6 @@ def main():
     """Command-line entry point for the optimization script."""
     parser = argparse.ArgumentParser(description="PoCADuck Point Cloud Optimizer")
     
-    parser.add_argument("--base-path", type=str, required=True,
-                        help="Base path for storage configuration")
     parser.add_argument("--source-index", type=str,
                         help="Path to source index (if different from base_path/unified_index.db)")
     parser.add_argument("--target-path", type=str,
@@ -483,22 +481,8 @@ def main():
     parser.add_argument("--labels-file", type=str,
                         help="File containing labels to process, one per line (default: all labels)")
     
-    # Add cloud storage related arguments
-    parser.add_argument("--storage-type", type=str, default="local",
-                        choices=["local", "s3", "gcs", "azure"],
-                        help="Storage backend type (default: local)")
-    parser.add_argument("--region", type=str,
-                        help="Cloud region (for S3, GCS)")
-    parser.add_argument("--endpoint", type=str,
-                        help="Custom endpoint URL (for S3)")
-    parser.add_argument("--access-key", type=str,
-                        help="Access key ID (for S3, Azure)")
-    parser.add_argument("--secret-key", type=str,
-                        help="Secret access key (for S3, Azure)")
-    parser.add_argument("--token", type=str,
-                        help="Session token (for S3)")
-    parser.add_argument("--container", type=str,
-                        help="Container name (for Azure)")
+    # Add storage configuration arguments
+    StorageConfig.add_storage_args(parser)
     
     # Verbosity control
     parser.add_argument("--quiet", action="store_true",
@@ -506,27 +490,8 @@ def main():
     
     args = parser.parse_args()
     
-    # Configure storage
-    storage_kwargs = {
-        "base_path": args.base_path,
-        "storage_type": args.storage_type
-    }
-    
-    # Add cloud-specific parameters if provided
-    if args.region:
-        storage_kwargs["region"] = args.region
-    if args.endpoint:
-        storage_kwargs["endpoint_url"] = args.endpoint
-    if args.access_key:
-        storage_kwargs["access_key_id"] = args.access_key
-    if args.secret_key:
-        storage_kwargs["secret_access_key"] = args.secret_key
-    if args.token:
-        storage_kwargs["session_token"] = args.token
-    if args.container:
-        storage_kwargs["container"] = args.container
-    
-    storage_config = StorageConfig(**storage_kwargs)
+    # Configure storage using the new class method
+    storage_config = StorageConfig.from_args(args)
     
     # Get source index path
     source_index_path = args.source_index

--- a/optimize_point_cloud.py
+++ b/optimize_point_cloud.py
@@ -297,8 +297,8 @@ def consolidate_optimized_indices(
         target_index_path = os.path.join(target_path, "optimized_index.db")
     
     if verbose:
-        print(f"Consolidating optimized indices from {target_path}")
-        print(f"Target index: {target_index_path}")
+        print(f"Consolidating optimized indices from {target_path}", flush=True)
+        print(f"Target index: {target_index_path}", flush=True)
     
     # Find all optimizer worker directories
     worker_dirs = [d for d in os.listdir(target_path)
@@ -306,16 +306,16 @@ def consolidate_optimized_indices(
     
     if not worker_dirs:
         if verbose:
-            print("No worker directories found. Nothing to consolidate.")
+            print("No worker directories found. Nothing to consolidate.", flush=True)
         return
     
     if verbose:
-        print(f"Found {len(worker_dirs)} worker directories")
+        print(f"Found {len(worker_dirs)} worker directories", flush=True)
     
     # Create/connect to target index
     if os.path.exists(target_index_path):
         if verbose:
-            print(f"Removing existing index at {target_index_path}")
+            print(f"Removing existing index at {target_index_path}", flush=True)
         os.remove(target_index_path)
     
     target_con = duckdb.connect(target_index_path)
@@ -346,7 +346,7 @@ def consolidate_optimized_indices(
         
         if not os.path.exists(metadata_path):
             if verbose:
-                print(f"Skipping {worker_dir}: No metadata file found")
+                print(f"Skipping {worker_dir}: No metadata file found", flush=True)
             continue
         
         try:
@@ -359,13 +359,13 @@ def consolidate_optimized_indices(
             if verbose:
                 worker_stats = metadata.get("stats", {})
                 labels_count = worker_stats.get("total_labels", 0)
-                print(f"Processing {worker_dir} (worker_id: {worker_id}): {labels_count} labels in {len(files_info)} files")
+                print(f"Processing {worker_dir} (worker_id: {worker_id}): {labels_count} labels in {len(files_info)} files", flush=True)
             
             # For each file, read the actual parquet data to build the index
             for file_path, file_info in files_info.items():
                 if not os.path.exists(file_path):
                     if verbose:
-                        print(f"Warning: File {file_path} not found, skipping")
+                        print(f"Warning: File {file_path} not found, skipping", flush=True)
                     continue
                 
                 try:
@@ -389,22 +389,22 @@ def consolidate_optimized_indices(
                     
                 except Exception as e:
                     if verbose:
-                        print(f"Error processing file {file_path}: {str(e)}")
+                        print(f"Error processing file {file_path}: {str(e)}", flush=True)
             
         except Exception as e:
             if verbose:
-                print(f"Error processing {worker_dir}: {str(e)}")
+                print(f"Error processing {worker_dir}: {str(e)}", flush=True)
     
     # Create indexes for performance
     if verbose:
-        print("Creating index on label column...")
+        print("Creating index on label column...", flush=True)
     target_con.execute("CREATE INDEX idx_label ON point_cloud_index(label)")
     
     # Commit and close connection
     target_con.close()
     
     if verbose:
-        print(f"Consolidation complete! Total labels in optimized index: {total_labels}")
+        print(f"Consolidation complete! Total labels in optimized index: {total_labels}", flush=True)
 
 def shard_labels(
     storage_config: StorageConfig,

--- a/optimize_point_cloud.py
+++ b/optimize_point_cloud.py
@@ -463,7 +463,7 @@ def shard_labels(
     # Write shards to files
     shard_files = []
     for i, shard in enumerate(shards):
-        shard_file = os.path.join(output_dir, f"labels_shard_{i}.txt")
+        shard_file = os.path.join(output_dir, f"labels_shard_{i+1}.txt")
         with open(shard_file, 'w') as f:
             f.write("\n".join(str(label) for label in shard))
         

--- a/optimize_point_cloud.py
+++ b/optimize_point_cloud.py
@@ -119,15 +119,11 @@ def optimize_point_clouds(
     start_time = time.time()
     
     if verbose:
-        print(f"Processing {len(labels)} labels in batches of {batch_size}...")
+        print(f"Processing {len(labels)} labels in batches of {batch_size}...", flush=True)
     
     for i in range(0, len(labels), batch_size):
         batch_labels = labels[i:i+batch_size]
         batch_start_time = time.time()
-        
-        if verbose:
-            print(f"Processing batch {i//batch_size + 1}/{(len(labels) + batch_size - 1)//batch_size}: "
-                  f"{len(batch_labels)} labels")
         
         try:
             # Get all file paths for this batch of labels in one query
@@ -238,9 +234,9 @@ def optimize_point_clouds(
                 cumulative_elapsed = time.time() - start_time
                 cumulative_labels_per_sec = processed_count / cumulative_elapsed if cumulative_elapsed > 0 else 0
                 
-                print(f"Worker {worker_id} - Batch {i//batch_size + 1}/{(len(labels) + batch_size - 1)//batch_size}: "
+                print(f"{worker_id}: Batch {i//batch_size + 1}/{(len(labels) + batch_size - 1)//batch_size}: "
                       f"{labels_processed_in_batch}/{len(batch_labels)} labels in {batch_elapsed:.2f}s "
-                      f"(batch: {batch_labels_per_sec:.1f} labels/s, cumulative: {cumulative_labels_per_sec:.1f} labels/s)")
+                      f"(batch: {batch_labels_per_sec:.1f} labels/s, cumulative: {cumulative_labels_per_sec:.1f} labels/s)", flush=True)
                 
         except Exception as e:
             if verbose:

--- a/pocaduck/storage_config.py
+++ b/pocaduck/storage_config.py
@@ -8,6 +8,7 @@ including local and cloud storage options (S3, GCS, Azure).
 from dataclasses import dataclass, field
 from typing import Optional, Dict, Any, Union
 from urllib.parse import urlparse
+import argparse
 
 
 @dataclass
@@ -100,3 +101,125 @@ class StorageConfig:
         config.update(self.extra_config)
         
         return config
+    
+    @classmethod
+    def add_storage_args(cls, parser: argparse.ArgumentParser) -> None:
+        """
+        Add storage-related arguments to an ArgumentParser.
+        
+        Args:
+            parser: ArgumentParser to add storage arguments to
+        """
+        parser.add_argument("--base-path", type=str, required=True,
+                            help="Base path for storage (local path, s3://, gs://, or azure://)")
+        
+        # S3 arguments
+        s3_group = parser.add_argument_group("S3 Storage Options")
+        s3_group.add_argument("--s3-region", type=str,
+                             help="AWS S3 region")
+        s3_group.add_argument("--s3-access-key-id", type=str,
+                             help="AWS S3 access key ID")
+        s3_group.add_argument("--s3-secret-access-key", type=str,
+                             help="AWS S3 secret access key")
+        s3_group.add_argument("--s3-session-token", type=str,
+                             help="AWS S3 session token")
+        s3_group.add_argument("--s3-endpoint-url", type=str,
+                             help="Custom S3 endpoint URL")
+        
+        # GCS arguments
+        gcs_group = parser.add_argument_group("Google Cloud Storage Options")
+        gcs_group.add_argument("--gcs-project-id", type=str,
+                              help="Google Cloud project ID")
+        gcs_group.add_argument("--gcs-credentials", type=str,
+                              help="Path to Google Cloud credentials JSON file")
+        
+        # Azure arguments
+        azure_group = parser.add_argument_group("Azure Storage Options")
+        azure_group.add_argument("--azure-connection-string", type=str,
+                                help="Azure storage connection string")
+    
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> "StorageConfig":
+        """
+        Create a StorageConfig instance from parsed command line arguments.
+        
+        Args:
+            args: Parsed arguments from ArgumentParser
+            
+        Returns:
+            StorageConfig instance
+            
+        Raises:
+            ValueError: If invalid parameter combinations are provided
+        """
+        # Start with base path
+        kwargs = {"base_path": args.base_path}
+        
+        # Determine expected storage type from base_path
+        parsed_url = urlparse(args.base_path)
+        expected_storage_type = parsed_url.scheme if parsed_url.scheme else "local"
+        
+        # Collect provided parameters by storage type
+        s3_params = {}
+        gcs_params = {}
+        azure_params = {}
+        extra_params = {}
+        
+        # S3 parameters
+        if hasattr(args, 's3_region') and args.s3_region:
+            s3_params['s3_region'] = args.s3_region
+        if hasattr(args, 's3_access_key_id') and args.s3_access_key_id:
+            s3_params['s3_access_key_id'] = args.s3_access_key_id
+        if hasattr(args, 's3_secret_access_key') and args.s3_secret_access_key:
+            s3_params['s3_secret_access_key'] = args.s3_secret_access_key
+        if hasattr(args, 's3_session_token') and args.s3_session_token:
+            extra_params['s3_session_token'] = args.s3_session_token
+        if hasattr(args, 's3_endpoint_url') and args.s3_endpoint_url:
+            extra_params['s3_endpoint_url'] = args.s3_endpoint_url
+            
+        # GCS parameters
+        if hasattr(args, 'gcs_project_id') and args.gcs_project_id:
+            gcs_params['gcs_project_id'] = args.gcs_project_id
+        if hasattr(args, 'gcs_credentials') and args.gcs_credentials:
+            gcs_params['gcs_credentials'] = args.gcs_credentials
+            
+        # Azure parameters
+        if hasattr(args, 'azure_connection_string') and args.azure_connection_string:
+            azure_params['azure_storage_connection_string'] = args.azure_connection_string
+        
+        # Validate parameter combinations
+        provided_storage_types = []
+        if s3_params:
+            provided_storage_types.append("s3")
+        if gcs_params:
+            provided_storage_types.append("gcs")
+        if azure_params:
+            provided_storage_types.append("azure")
+        
+        # Check for conflicting storage parameters
+        if len(provided_storage_types) > 1:
+            raise ValueError(f"Conflicting storage parameters provided for: {', '.join(provided_storage_types)}. "
+                           f"Please provide parameters for only one storage type.")
+        
+        # Check if provided parameters match expected storage type
+        if provided_storage_types:
+            provided_type = provided_storage_types[0]
+            if expected_storage_type == "local" and provided_type:
+                raise ValueError(f"Local path provided but {provided_type} parameters specified. "
+                               f"Use a {provided_type}:// URL or remove {provided_type} parameters.")
+            elif expected_storage_type == "s3" and provided_type != "s3":
+                raise ValueError(f"S3 URL provided but {provided_type} parameters specified.")
+            elif expected_storage_type in ("gs", "gcs") and provided_type != "gcs":
+                raise ValueError(f"GCS URL provided but {provided_type} parameters specified.")
+            elif expected_storage_type in ("azure", "az") and provided_type != "azure":
+                raise ValueError(f"Azure URL provided but {provided_type} parameters specified.")
+        
+        # Add the appropriate parameters
+        kwargs.update(s3_params)
+        kwargs.update(gcs_params)
+        kwargs.update(azure_params)
+        
+        if extra_params:
+            kwargs['extra_config'] = extra_params
+        
+        return cls(**kwargs)

--- a/tests/test_optimize_point_cloud_cli.py
+++ b/tests/test_optimize_point_cloud_cli.py
@@ -1,0 +1,258 @@
+"""
+Tests for optimize_point_cloud.py CLI functionality using mocking.
+
+This demonstrates how to test CLI scripts that use the new StorageConfig
+parameter parsing without actually running the optimization pipeline.
+"""
+
+import unittest
+import argparse
+import tempfile
+import os
+from unittest.mock import patch, MagicMock, call
+import sys
+from pathlib import Path
+
+# Add the project root to the path so we can import optimize_point_cloud
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import optimize_point_cloud
+from pocaduck.storage_config import StorageConfig
+
+
+class TestOptimizePointCloudCLI(unittest.TestCase):
+    """Test CLI functionality of optimize_point_cloud.py script."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.test_base_path = os.path.join(self.temp_dir, "test_data")
+        os.makedirs(self.test_base_path, exist_ok=True)
+        
+        # Create a mock unified index file
+        self.mock_index_path = os.path.join(self.test_base_path, "unified_index.db")
+        with open(self.mock_index_path, 'w') as f:
+            f.write("mock database file")
+    
+    def tearDown(self):
+        """Clean up test fixtures."""
+        import shutil
+        shutil.rmtree(self.temp_dir)
+    
+    @patch('optimize_point_cloud.shard_labels')
+    @patch('optimize_point_cloud.StorageConfig.from_args')
+    def test_shard_action_cli_parsing(self, mock_from_args, mock_shard_labels):
+        """Test that shard action correctly parses CLI arguments."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_from_args.return_value = mock_config
+        mock_shard_labels.return_value = ['shard1.txt', 'shard2.txt']
+        
+        # Simulate command line arguments
+        test_args = [
+            '--action', 'shard',
+            '--base-path', self.test_base_path,
+            '--num-shards', '4',
+            '--shard-output-dir', self.temp_dir
+        ]
+        
+        # Mock sys.argv and run main
+        with patch('sys.argv', ['optimize_point_cloud.py'] + test_args):
+            optimize_point_cloud.main()
+        
+        # Verify StorageConfig.from_args was called with parsed arguments
+        mock_from_args.assert_called_once()
+        args = mock_from_args.call_args[0][0]
+        self.assertEqual(args.base_path, self.test_base_path)
+        self.assertEqual(args.action, 'shard')
+        self.assertEqual(args.num_shards, 4)
+        
+        # Verify shard_labels was called with correct parameters
+        mock_shard_labels.assert_called_once_with(
+            storage_config=mock_config,
+            source_index_path=self.mock_index_path,
+            num_shards=4,
+            output_dir=self.temp_dir,
+            verbose=True
+        )
+    
+    @patch('optimize_point_cloud.optimize_point_clouds')
+    @patch('optimize_point_cloud.StorageConfig.from_args')
+    def test_optimize_action_with_s3_storage(self, mock_from_args, mock_optimize):
+        """Test optimize action with S3 storage parameters."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.storage_type = 's3'
+        mock_from_args.return_value = mock_config
+        
+        # Create a mock labels file
+        labels_file = os.path.join(self.temp_dir, "labels_shard_0.txt")
+        with open(labels_file, 'w') as f:
+            f.write("12345\n67890\n")
+        
+        # Simulate command line arguments with S3 storage
+        test_args = [
+            '--action', 'optimize',
+            '--base-path', 's3://test-bucket/data',
+            '--s3-region', 'us-west-2',
+            '--s3-access-key-id', 'test-key',
+            '--labels-file', labels_file,
+            '--worker-id', 'test-worker',
+            '--threads', '8'
+        ]
+        
+        with patch('sys.argv', ['optimize_point_cloud.py'] + test_args):
+            optimize_point_cloud.main()
+        
+        # Verify StorageConfig.from_args was called
+        mock_from_args.assert_called_once()
+        args = mock_from_args.call_args[0][0]
+        self.assertEqual(args.base_path, 's3://test-bucket/data')
+        self.assertEqual(args.s3_region, 'us-west-2')
+        self.assertEqual(args.s3_access_key_id, 'test-key')
+        
+        # Verify optimize_point_clouds was called with correct parameters
+        mock_optimize.assert_called_once()
+        call_kwargs = mock_optimize.call_args[1]
+        self.assertEqual(call_kwargs['storage_config'], mock_config)
+        self.assertEqual(call_kwargs['worker_id'], 'test-worker')
+        self.assertEqual(call_kwargs['threads'], 8)
+        self.assertEqual(call_kwargs['labels_to_process'], [12345, 67890])
+    
+    @patch('optimize_point_cloud.consolidate_optimized_indices')
+    @patch('optimize_point_cloud.StorageConfig.from_args')
+    def test_consolidate_action_cli_parsing(self, mock_from_args, mock_consolidate):
+        """Test consolidate action CLI parsing."""
+        mock_config = MagicMock()
+        mock_from_args.return_value = mock_config
+        
+        test_args = [
+            '--action', 'consolidate',
+            '--base-path', self.test_base_path,
+            '--target-path', os.path.join(self.temp_dir, 'optimized'),
+            '--threads', '16',
+            '--quiet'
+        ]
+        
+        with patch('sys.argv', ['optimize_point_cloud.py'] + test_args):
+            optimize_point_cloud.main()
+        
+        # Verify consolidate was called with correct parameters
+        mock_consolidate.assert_called_once_with(
+            storage_config=mock_config,
+            target_path=os.path.join(self.temp_dir, 'optimized'),
+            target_index_path=None,
+            threads=16,
+            verbose=False  # --quiet flag should set verbose=False
+        )
+    
+    @patch('optimize_point_cloud.StorageConfig.from_args')
+    def test_storage_config_validation_error(self, mock_from_args):
+        """Test that StorageConfig validation errors are properly handled."""
+        # Make StorageConfig.from_args raise a validation error
+        mock_from_args.side_effect = ValueError("Conflicting storage parameters provided")
+        
+        test_args = [
+            '--action', 'shard',
+            '--base-path', '/tmp/test',
+            '--s3-region', 'us-west-2',  # This conflicts with local path
+            '--num-shards', '2'
+        ]
+        
+        with patch('sys.argv', ['optimize_point_cloud.py'] + test_args):
+            with self.assertRaises(ValueError) as cm:
+                optimize_point_cloud.main()
+            
+            self.assertIn("Conflicting storage parameters", str(cm.exception))
+    
+    def test_argument_parser_setup(self):
+        """Test that the argument parser is set up correctly."""
+        parser = argparse.ArgumentParser(description="Test")
+        StorageConfig.add_storage_args(parser)
+        
+        # Test that all expected arguments are added
+        help_text = parser.format_help()
+        
+        # Check for storage arguments
+        self.assertIn("--base-path", help_text)
+        self.assertIn("S3 Storage Options", help_text)
+        self.assertIn("--s3-region", help_text)
+        self.assertIn("--s3-access-key-id", help_text)
+        self.assertIn("Google Cloud Storage Options", help_text)
+        self.assertIn("--gcs-project-id", help_text)
+        self.assertIn("Azure Storage Options", help_text)
+        self.assertIn("--azure-connection-string", help_text)
+    
+    @patch('optimize_point_cloud.optimize_point_clouds')
+    @patch('optimize_point_cloud.StorageConfig.from_args')
+    def test_labels_parsing_from_command_line(self, mock_from_args, mock_optimize):
+        """Test parsing labels from command line argument."""
+        mock_config = MagicMock()
+        mock_from_args.return_value = mock_config
+        
+        test_args = [
+            '--action', 'optimize',
+            '--base-path', self.test_base_path,
+            '--labels', '123,456,789',
+            '--worker-id', 'test'
+        ]
+        
+        with patch('sys.argv', ['optimize_point_cloud.py'] + test_args):
+            optimize_point_cloud.main()
+        
+        # Verify labels were parsed correctly
+        call_kwargs = mock_optimize.call_args[1]
+        self.assertEqual(call_kwargs['labels_to_process'], [123, 456, 789])
+    
+    def test_missing_required_arguments(self):
+        """Test error handling for missing required arguments."""
+        # Missing --base-path should cause parser error
+        with patch('sys.argv', ['optimize_point_cloud.py', '--action', 'shard']):
+            with patch('sys.stderr'):  # Suppress error output
+                with self.assertRaises(SystemExit):
+                    optimize_point_cloud.main()
+        
+        # Missing --num-shards for shard action should cause error
+        with patch('sys.argv', ['optimize_point_cloud.py', '--action', 'shard', '--base-path', '/tmp']):
+            with patch('sys.stderr'):  # Suppress error output
+                with self.assertRaises(SystemExit):
+                    optimize_point_cloud.main()
+
+
+class TestStorageConfigMockingStrategies(unittest.TestCase):
+    """Demonstrate different mocking strategies for testing StorageConfig."""
+    
+    def test_mock_storage_config_creation(self):
+        """Show how to mock StorageConfig for isolated testing."""
+        with patch('pocaduck.storage_config.StorageConfig') as MockStorageConfig:
+            # Create a mock instance
+            mock_instance = MagicMock()
+            mock_instance.base_path = '/test/path'
+            mock_instance.storage_type = 'local'
+            MockStorageConfig.return_value = mock_instance
+            
+            # Test code that uses StorageConfig
+            config = StorageConfig(base_path='/test/path')
+            self.assertEqual(config.base_path, '/test/path')
+            self.assertEqual(config.storage_type, 'local')
+    
+    def test_mock_duckdb_config(self):
+        """Show how to mock DuckDB configuration for testing."""
+        config = StorageConfig(base_path='/test/path')
+        
+        with patch.object(config, 'get_duckdb_config') as mock_get_config:
+            mock_get_config.return_value = {'test_setting': 'test_value'}
+            
+            duckdb_config = config.get_duckdb_config()
+            self.assertEqual(duckdb_config, {'test_setting': 'test_value'})
+    
+    @patch.dict(os.environ, {'AWS_REGION': 'us-east-1'})
+    def test_mock_environment_variables(self):
+        """Show how to mock environment variables for testing."""
+        # This demonstrates testing with environment variables
+        # even though our current StorageConfig doesn't use them directly
+        self.assertEqual(os.environ['AWS_REGION'], 'us-east-1')
+
+
+if __name__ == '__main__':
+    # Run with verbose output to see test descriptions
+    unittest.main(verbosity=2)

--- a/tests/test_storage_config_cli.py
+++ b/tests/test_storage_config_cli.py
@@ -1,0 +1,208 @@
+"""
+Tests for StorageConfig CLI parameter parsing functionality.
+
+This module tests the new add_storage_args() and from_args() class methods
+to ensure proper CLI parameter handling and validation.
+"""
+
+import unittest
+import argparse
+from unittest.mock import patch, MagicMock
+import tempfile
+import os
+
+from pocaduck.storage_config import StorageConfig
+
+
+class TestStorageConfigCLI(unittest.TestCase):
+    """Test CLI parameter parsing for StorageConfig."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.parser = argparse.ArgumentParser()
+        StorageConfig.add_storage_args(self.parser)
+    
+    def test_local_storage_basic(self):
+        """Test basic local storage configuration."""
+        args = self.parser.parse_args(['--base-path', '/tmp/test'])
+        config = StorageConfig.from_args(args)
+        
+        self.assertEqual(config.base_path, '/tmp/test')
+        self.assertEqual(config.storage_type, 'local')
+        self.assertIsNone(config.s3_region)
+        self.assertIsNone(config.gcs_project_id)
+    
+    def test_s3_storage_complete(self):
+        """Test S3 storage with all parameters."""
+        args = self.parser.parse_args([
+            '--base-path', 's3://test-bucket/path',
+            '--s3-region', 'us-west-2',
+            '--s3-access-key-id', 'test-key',
+            '--s3-secret-access-key', 'test-secret',
+            '--s3-session-token', 'test-token',
+            '--s3-endpoint-url', 'https://custom-endpoint'
+        ])
+        config = StorageConfig.from_args(args)
+        
+        self.assertEqual(config.base_path, 's3://test-bucket/path')
+        self.assertEqual(config.storage_type, 's3')
+        self.assertEqual(config.s3_region, 'us-west-2')
+        self.assertEqual(config.s3_access_key_id, 'test-key')
+        self.assertEqual(config.s3_secret_access_key, 'test-secret')
+        self.assertEqual(config.extra_config['s3_session_token'], 'test-token')
+        self.assertEqual(config.extra_config['s3_endpoint_url'], 'https://custom-endpoint')
+    
+    def test_gcs_storage_complete(self):
+        """Test GCS storage with all parameters."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            f.write('{"type": "service_account"}')
+            creds_path = f.name
+        
+        try:
+            args = self.parser.parse_args([
+                '--base-path', 'gs://test-bucket/path',
+                '--gcs-project-id', 'test-project',
+                '--gcs-credentials', creds_path
+            ])
+            config = StorageConfig.from_args(args)
+            
+            self.assertEqual(config.base_path, 'gs://test-bucket/path')
+            self.assertEqual(config.storage_type, 'gs')
+            self.assertEqual(config.gcs_project_id, 'test-project')
+            self.assertEqual(config.gcs_credentials, creds_path)
+        finally:
+            os.unlink(creds_path)
+    
+    def test_azure_storage_complete(self):
+        """Test Azure storage with connection string."""
+        args = self.parser.parse_args([
+            '--base-path', 'azure://container/path',
+            '--azure-connection-string', 'DefaultEndpointsProtocol=https;AccountName=test;'
+        ])
+        config = StorageConfig.from_args(args)
+        
+        self.assertEqual(config.base_path, 'azure://container/path')
+        self.assertEqual(config.storage_type, 'azure')
+        self.assertEqual(config.azure_storage_connection_string, 
+                        'DefaultEndpointsProtocol=https;AccountName=test;')
+    
+    def test_conflicting_storage_parameters(self):
+        """Test that conflicting storage parameters raise an error."""
+        args = self.parser.parse_args([
+            '--base-path', '/tmp/test',
+            '--s3-region', 'us-west-2',
+            '--gcs-project-id', 'test-project'
+        ])
+        
+        with self.assertRaises(ValueError) as cm:
+            StorageConfig.from_args(args)
+        
+        self.assertIn("Conflicting storage parameters", str(cm.exception))
+        self.assertIn("s3", str(cm.exception))
+        self.assertIn("gcs", str(cm.exception))
+    
+    def test_local_path_with_cloud_parameters(self):
+        """Test that local path with cloud parameters raises an error."""
+        args = self.parser.parse_args([
+            '--base-path', '/tmp/test',
+            '--s3-region', 'us-west-2'
+        ])
+        
+        with self.assertRaises(ValueError) as cm:
+            StorageConfig.from_args(args)
+        
+        self.assertIn("Local path provided but s3 parameters specified", str(cm.exception))
+    
+    def test_s3_url_with_gcs_parameters(self):
+        """Test that S3 URL with GCS parameters raises an error."""
+        args = self.parser.parse_args([
+            '--base-path', 's3://bucket/path',
+            '--gcs-project-id', 'test-project'
+        ])
+        
+        with self.assertRaises(ValueError) as cm:
+            StorageConfig.from_args(args)
+        
+        self.assertIn("S3 URL provided but gcs parameters specified", str(cm.exception))
+    
+    def test_missing_required_base_path(self):
+        """Test that missing base-path raises an error."""
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args([])
+    
+    def test_empty_parameters_ignored(self):
+        """Test that empty/None parameters are ignored."""
+        args = self.parser.parse_args([
+            '--base-path', 's3://bucket/path',
+            '--s3-region', 'us-west-2'
+            # Note: other S3 params are None/empty
+        ])
+        config = StorageConfig.from_args(args)
+        
+        self.assertEqual(config.s3_region, 'us-west-2')
+        self.assertIsNone(config.s3_access_key_id)
+        self.assertIsNone(config.s3_secret_access_key)
+        self.assertEqual(config.extra_config, {})
+
+
+class TestStorageConfigCLIIntegration(unittest.TestCase):
+    """Integration tests for CLI parameter parsing with actual scripts."""
+    
+    def test_mock_script_usage(self):
+        """Test how a script would use the new CLI functionality."""
+        
+        # Simulate a script that uses StorageConfig
+        def mock_script_main(argv):
+            parser = argparse.ArgumentParser(description="Mock script")
+            parser.add_argument("--action", choices=["test"], default="test")
+            
+            # Add storage args using the new method
+            StorageConfig.add_storage_args(parser)
+            
+            # Parse args
+            args = parser.parse_args(argv)
+            
+            # Create storage config using the new method
+            storage_config = StorageConfig.from_args(args)
+            
+            return storage_config
+        
+        # Test local storage
+        config = mock_script_main([
+            '--base-path', '/tmp/test',
+            '--action', 'test'
+        ])
+        self.assertEqual(config.storage_type, 'local')
+        
+        # Test S3 storage
+        config = mock_script_main([
+            '--base-path', 's3://bucket/path',
+            '--s3-region', 'us-east-1',
+            '--action', 'test'
+        ])
+        self.assertEqual(config.storage_type, 's3')
+        self.assertEqual(config.s3_region, 'us-east-1')
+    
+    def test_help_message_generation(self):
+        """Test that help messages are properly generated."""
+        parser = argparse.ArgumentParser()
+        StorageConfig.add_storage_args(parser)
+        
+        # This would normally print help, but we just want to make sure it doesn't crash
+        with patch('sys.stdout'):
+            with self.assertRaises(SystemExit):
+                parser.parse_args(['--help'])
+    
+    @patch('pocaduck.storage_config.StorageConfig.__post_init__')
+    def test_validation_bypass_for_testing(self, mock_post_init):
+        """Test that we can bypass validation for unit testing if needed."""
+        # Sometimes in tests you want to create invalid configs to test error handling
+        mock_post_init.return_value = None
+        
+        # This would normally fail validation, but with mocking it works
+        config = StorageConfig(base_path="invalid://path")
+        self.assertEqual(config.base_path, "invalid://path")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Scanning data blockwise and agglomerating the point clouds for each worker naturally leads to data ordered by worker and block. Although pocaduck can return a point cloud across all blocks for a given label, the data isn't optimal for querying by label. This PR allows data to be reorganized into large parquet files but now point cloud data for any given label is now localized to improve query performance. @stuarteberg